### PR TITLE
fix: dont run on every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI Pipeline
 
 on:
-  push:
-    branches-ignore: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:


### PR DESCRIPTION
Only run the CI steps on PRs to reduce gh action usage