### PR TITLE
♻️ refactor: game logic

### DIFF
--- a/backend_gamelogic/src/RemoteTournament.ts
+++ b/backend_gamelogic/src/RemoteTournament.ts
@@ -1,0 +1,20 @@
+import { TournamentPlayer, GamePairing, Tournament } from "./Tournament";
+
+export class RemoteTournament extends Tournament {
+  private createdAt: Date;
+  constructor() {
+    super([]);
+    this.createdAt = new Date();
+  }
+  addPlayer(player: TournamentPlayer): void {
+    this["activePlayers"].add(player);
+  }
+
+  removePlayer(player: TournamentPlayer): void {
+    this["activePlayers"].delete(player);
+  }
+
+  getCreatedAt(): Date {
+    return this.createdAt;
+  }
+}

--- a/backend_gamelogic/src/config.ts
+++ b/backend_gamelogic/src/config.ts
@@ -49,6 +49,9 @@ export const config = {
   // Backend database service URL
   backendDatabase: {
     url: getOptionalEnvVar("BACKEND_DATABASE_URL", "http://databank:3000"),
+    //TODO: Silas. belongs to authUtils.ts
+    authPrefix: getOptionalEnvVar("AUTH_PREFIX", "/api/auth"),
+    apiPrefix: getOptionalEnvVar("API_PREFIX", "/api"),
   },
 
   // Service authentication

--- a/backend_gamelogic/src/connection/AIConnection.ts
+++ b/backend_gamelogic/src/connection/AIConnection.ts
@@ -1,0 +1,42 @@
+import { GameManager } from "../gameManager.js";
+import { createGame } from "../gameUtils.js";
+import ConnectionSession from "./ConnectionSession.js";
+import { sendErrorToClient } from "../networkUtils.js";
+
+export default class AIConnection extends ConnectionSession {
+  constructor(connection: any, req: any, mode: string, gameManager: GameManager) {
+    super(connection, req, mode, gameManager);
+  }
+
+  protected async handleMessage(data: any) {
+    switch (data.type) {
+      case "newGame":
+        if (!data.difficulty || !["easy", "medium", "hard"].includes(data.difficulty)) {
+          sendErrorToClient(this.connection, "Invalid AI difficulty");
+          return;
+        }
+        this.stopGame();
+        this.game = createGame(this.mode, (game) => {
+          this.gameManager.removeActiveGame(game);
+        });
+        this.game.aiPlayer.aiDifficulty = data.difficulty;
+        this.game.clients.set(2, {
+          playerInfo: { userId: 0, username: this.mode },
+          connection: this.connection,
+        });
+        this.gameManager.addActiveGame(this.game);
+        this.game.freezeBall();
+        this.game.runGameCountdown();
+        break;
+      case "nextGame":
+        this.stopGame();
+        break;
+      default:
+        break;
+    }
+  }
+
+  protected onClose() {
+    this.stopGame();
+  }
+}

--- a/backend_gamelogic/src/connection/AIConnection.ts
+++ b/backend_gamelogic/src/connection/AIConnection.ts
@@ -36,7 +36,7 @@ export default class AIConnection extends ConnectionSession {
     }
   }
 
-  protected onClose() {
+  public onClose() {
     this.stopGame();
   }
 }

--- a/backend_gamelogic/src/connection/ConnectionSession.ts
+++ b/backend_gamelogic/src/connection/ConnectionSession.ts
@@ -18,7 +18,7 @@ export default abstract class ConnectionSession {
     // Note: message and close listeners are set up by the server handler
   }
 
-  protected async onMessage(raw: any) {
+  public async onMessage(raw: any) {
     let data: any = null;
     try {
       data = JSON.parse(raw.toString());
@@ -46,28 +46,7 @@ export default abstract class ConnectionSession {
   }
 
   protected abstract handleMessage(data: any): Promise<void>;
-  protected abstract onClose(): void;
-
-  // Public wrapper methods for the server handler
-  public async onMessagePublic(raw: any) {
-    console.log(`🔵 onMessagePublic called for ${this.mode} mode`);
-    try {
-      await this.onMessage(raw);
-    } catch (err) {
-      console.error(`🔴 onMessagePublic error for ${this.mode}:`, err);
-      throw err;
-    }
-  }
-
-  public onClosePublic() {
-    console.log(`🔵 onClosePublic called for ${this.mode} mode`);
-    try {
-      this.onClose();
-    } catch (err) {
-      console.error(`🔴 onClosePublic error for ${this.mode}:`, err);
-    }
-    this.game = null;
-  }
+  public abstract onClose(): void;
 
   protected stopGame() {
     try {

--- a/backend_gamelogic/src/connection/ConnectionSession.ts
+++ b/backend_gamelogic/src/connection/ConnectionSession.ts
@@ -1,0 +1,95 @@
+import { GameServer } from "../gameTypes.js";
+import { GameManager } from "../gameManager.js";
+import { createGame } from "../gameUtils.js";
+
+export default abstract class ConnectionSession {
+  public connection: any;
+  public req: any;
+  public mode: string;
+  public gameManager: GameManager;
+
+  public game: GameServer | null = null;
+
+  constructor(connection: any, req: any, mode: string, gameManager: GameManager) {
+    this.connection = connection;
+    this.req = req;
+    this.mode = mode;
+    this.gameManager = gameManager;
+    // Note: message and close listeners are set up by the server handler
+  }
+
+  protected async onMessage(raw: any) {
+    let data: any = null;
+    try {
+      data = JSON.parse(raw.toString());
+    } catch (err) {
+      try {
+        this.connection.send(JSON.stringify({ type: "error", message: "Failed to parse message" }));
+      } catch (e) {}
+      return;
+    }
+
+    try {
+      if (data.type === "playerInput") {
+        if (!this.game) return;
+        const input = data.data as { player: number; action: string };
+        this.game.handlePlayerInput(input);
+        return;
+      }
+      await this.handleMessage(data);
+    } catch (err) {
+      console.error("ConnectionSession handleMessage error:", err);
+      try {
+        this.connection.send(JSON.stringify({ type: "error", message: "Server error" }));
+      } catch (e) {}
+    }
+  }
+
+  protected abstract handleMessage(data: any): Promise<void>;
+  protected abstract onClose(): void;
+
+  // Public wrapper methods for the server handler
+  public async onMessagePublic(raw: any) {
+    console.log(`🔵 onMessagePublic called for ${this.mode} mode`);
+    try {
+      await this.onMessage(raw);
+    } catch (err) {
+      console.error(`🔴 onMessagePublic error for ${this.mode}:`, err);
+      throw err;
+    }
+  }
+
+  public onClosePublic() {
+    console.log(`🔵 onClosePublic called for ${this.mode} mode`);
+    try {
+      this.onClose();
+    } catch (err) {
+      console.error(`🔴 onClosePublic error for ${this.mode}:`, err);
+    }
+    this.game = null;
+  }
+
+  protected stopGame() {
+    try {
+      if (this.game) {
+        this.game.stop();
+        this.gameManager.removeActiveGame(this.game);
+        this.game = null;
+      }
+    } catch (err) {
+      console.error("Error stopping game:", err);
+    }
+  }
+
+  protected joinGame() {
+    this.game = createGame(this.mode, (game) => {
+      this.gameManager.removeActiveGame(game);
+    });
+    this.game.connect(2, { userId: 0, username: "Guest" }, this.connection);
+    this.gameManager.addActiveGame(this.game);
+    this.game.freezeBall();
+    this.game
+      .runGameCountdown()
+      .catch((err) => console.error("Error during online game countdown:", err));
+  }
+}

--- a/backend_gamelogic/src/connection/FriendConnection.ts
+++ b/backend_gamelogic/src/connection/FriendConnection.ts
@@ -1,0 +1,152 @@
+import ConnectionSession from "./ConnectionSession.js";
+import { GameManager } from "../gameManager.js";
+import { createGame } from "../gameUtils.js";
+import { config } from "../config.js";
+import { sendErrorToClient } from "../networkUtils.js";
+
+export default class FriendConnection extends ConnectionSession {
+  private userId: number;
+  private username: string;
+  private gameId: string;
+  private otherUserId: number | null = null;
+
+  constructor(
+    connection: any,
+    req: any,
+    mode: string,
+    gameManager: GameManager,
+    userId: number,
+    username: string,
+    gameId: string
+  ) {
+    super(connection, req, mode, gameManager);
+    this.userId = userId;
+    this.username = username;
+    this.gameId = gameId;
+  }
+
+  protected async handleMessage(data: any) {
+    switch (data.type) {
+      case "newGame":
+        if (this.fetchGame()) break;
+        if (!this.game) {
+          try {
+            await this.checkInvite();
+          } catch (err) {
+            sendErrorToClient(this.connection, (err as Error).message);
+            return;
+          }
+          this.fetchGame();
+        }
+        this.joinGame();
+        break;
+      case "nextGame":
+        this.stopGame();
+        break;
+      default:
+        break;
+    }
+  }
+
+  protected onClose() {
+    if (this.game) {
+      this.game.disconnect(this.connection);
+      if (this.game.connectionCount() === 0 && this.game.isWaiting) {
+        this.stopGame();
+      }
+    }
+  }
+
+  protected stopGame(): void {
+    try {
+      if (this.game && this.game.isConnected(this.connection)) {
+        this.game.stop();
+        this.gameManager.removeActiveGame(this.game);
+        this.game.clients.forEach((client) => {
+          this.gameManager.removeUserGame(client.playerInfo.userId, this.gameId);
+        });
+        this.game = null;
+      }
+    } catch (err) {
+      console.error("Error stopping game:", err);
+    }
+  }
+
+  private fetchGame(): boolean {
+    this.game = this.gameManager.getUserGame(this.userId, this.gameId);
+    if (this.game) {
+      this.game.updateConnection(this.userId, this.connection);
+      return true;
+    }
+    if (this.otherUserId !== null) {
+      this.game = this.gameManager.getUserGame(this.otherUserId, this.gameId);
+    }
+    return this.game !== null;
+  }
+
+  protected joinGame() {
+    if (!this.game) {
+      this.game = createGame(this.mode, (game) => {
+        this.gameManager.removeActiveGame(game);
+        this.gameManager.removeUserGame(this.userId, this.gameId);
+        if (this.otherUserId !== null) {
+          this.gameManager.removeUserGame(this.otherUserId, this.gameId);
+        }
+      });
+      this.game.connect(1, { userId: this.userId, username: this.username }, this.connection);
+      this.game.freezeBall();
+      this.game.gameId = this.gameId;
+      this.gameManager.addActiveGame(this.game);
+      this.gameManager.addUserGame(this.userId, this.game, this.gameId);
+      this.gameManager.setWaitingRemote({
+        playerInfo: { userId: this.userId, username: this.username },
+        connection: this.connection,
+        game: this.game,
+      });
+    } else {
+      if (!this.game.updateConnection(this.userId, this.connection)) {
+        let playerNum: 1 | 2 = this.game.clients.has(1) ? 2 : 1;
+        this.game.connect(
+          playerNum,
+          { userId: this.userId, username: this.username },
+          this.connection
+        );
+      }
+      this.gameManager.addActiveGame(this.game);
+      this.gameManager.addUserGame(this.userId, this.game, this.gameId);
+      if (this.game.connectionCount() !== 2) return;
+      this.game
+        .runGameCountdown()
+        .catch((err) => console.error("Error during online game countdown:", err));
+    }
+  }
+
+  private async checkInvite() {
+    const backendUrl = config.backendDatabase.url;
+    const resp = await fetch(`${backendUrl}/api/internal/game-invites/${this.gameId}`, {
+      headers: {
+        "X-Service-Token": config.serviceAuth.secret,
+      },
+    });
+    if (!resp.ok) {
+      const msg = await resp.text().catch(() => "");
+      const errorMsg = "This invitation is no longer valid.";
+      throw Error(errorMsg);
+    }
+
+    const json = await resp.json();
+    const invite = json.data;
+    if (!invite) {
+      const errorMsg = "This invitation is no longer valid.";
+      throw Error(errorMsg);
+    }
+
+    // Validate that the joining player is either inviter or invitee
+    const invitedIds = [Number(invite.inviter_id), Number(invite.invitee_id)];
+    if (!invitedIds.includes(Number(this.userId))) {
+      const errorMsg = "You are not authorized to join this game.";
+      throw Error(errorMsg);
+    }
+    this.otherUserId = invitedIds.find((id) => id !== Number(this.userId)) || null;
+  }
+}

--- a/backend_gamelogic/src/connection/FriendConnection.ts
+++ b/backend_gamelogic/src/connection/FriendConnection.ts
@@ -48,7 +48,7 @@ export default class FriendConnection extends ConnectionSession {
     }
   }
 
-  protected onClose() {
+  public onClose() {
     if (this.game) {
       this.game.disconnect(this.connection);
       if (this.game.connectionCount() === 0 && this.game.isWaiting) {

--- a/backend_gamelogic/src/connection/FriendConnection.ts
+++ b/backend_gamelogic/src/connection/FriendConnection.ts
@@ -129,7 +129,6 @@ export default class FriendConnection extends ConnectionSession {
       },
     });
     if (!resp.ok) {
-      const msg = await resp.text().catch(() => "");
       const errorMsg = "This invitation is no longer valid.";
       throw Error(errorMsg);
     }

--- a/backend_gamelogic/src/connection/LocalConnection.ts
+++ b/backend_gamelogic/src/connection/LocalConnection.ts
@@ -30,7 +30,7 @@ export default class LocalConnection extends ConnectionSession {
     }
   }
 
-  protected onClose() {
+  public onClose() {
     this.stopGame();
   }
 }

--- a/backend_gamelogic/src/connection/LocalConnection.ts
+++ b/backend_gamelogic/src/connection/LocalConnection.ts
@@ -1,0 +1,36 @@
+import { createGame } from "../gameUtils.js";
+import ConnectionSession from "./ConnectionSession.js";
+import { GameManager } from "../gameManager.js";
+
+export default class LocalConnection extends ConnectionSession {
+  constructor(connection: any, req: any, mode: string, gameManager: GameManager) {
+    super(connection, req, mode, gameManager);
+  }
+
+  protected async handleMessage(data: any) {
+    switch (data.type) {
+      case "newGame":
+        this.stopGame();
+        this.game = createGame(this.mode, (game) => {
+          this.gameManager.removeActiveGame(game);
+        });
+        this.game.clients.set(2, {
+          playerInfo: { userId: 0, username: this.mode },
+          connection: this.connection,
+        });
+        this.gameManager.addActiveGame(this.game);
+        this.game.freezeBall();
+        this.game.runGameCountdown();
+        break;
+      case "nextGame":
+        this.stopGame();
+        break;
+      default:
+        break;
+    }
+  }
+
+  protected onClose() {
+    this.stopGame();
+  }
+}

--- a/backend_gamelogic/src/connection/RemoteConnection.ts
+++ b/backend_gamelogic/src/connection/RemoteConnection.ts
@@ -1,0 +1,119 @@
+import ConnectionSession from "./ConnectionSession.js";
+import { GameManager } from "../gameManager.js";
+import { createGame } from "../gameUtils.js";
+
+export default class RemoteConnection extends ConnectionSession {
+  private userId: number;
+  private username: string;
+
+  constructor(
+    connection: any,
+    req: any,
+    mode: string,
+    gameManager: GameManager,
+    userId: number,
+    username: string
+  ) {
+    super(connection, req, mode, gameManager);
+    this.userId = userId;
+    this.username = username;
+  }
+
+  protected async handleMessage(data: any) {
+    console.log(`📨 RemoteConnection received message:`, data.type);
+    try {
+      switch (data.type) {
+        case "newGame":
+          if (this.fetchGame()) break;
+          this.stopGame();
+          this.joinGame();
+          console.log(`✅ Game joined/created for userId: ${this.userId}`);
+          break;
+        case "nextGame":
+          this.stopGame();
+          break;
+        default:
+          break;
+      }
+    } catch (err) {
+      console.error("❌ RemoteConnection handleMessage error:", err);
+      throw err;
+    }
+  }
+
+  protected onClose() {
+    if (this.game) {
+      this.game.disconnect(this.connection);
+    }
+  }
+
+  protected stopGame(): void {
+    try {
+      if (this.game && this.game.isConnected(this.connection)) {
+        this.game.stop();
+        this.gameManager.removeActiveGame(this.game);
+        this.game.clients.forEach((client) => {
+          this.gameManager.removeUserGame(client.playerInfo.userId);
+        });
+        if (this.gameManager.isWaitingRemote(this.userId)) {
+          this.gameManager.setWaitingRemote(null);
+        }
+        this.game = null;
+      }
+    } catch (err) {
+      console.error("Error stopping game:", err);
+    }
+  }
+
+  private fetchGame(): boolean {
+    this.game = this.gameManager.getUserGame(this.userId);
+    return this.game !== null && this.game.updateConnection(this.userId, this.connection);
+  }
+
+  protected joinGame() {
+    try {
+      console.log(`🎮 joinGame called for userId: ${this.userId}`);
+      const waitingRemotePlayer = this.gameManager.getWaitingRemote();
+
+      // Check if there's a waiting player and it's not the same user
+      if (waitingRemotePlayer && waitingRemotePlayer.playerInfo.userId !== this.userId) {
+        console.log(
+          `🤝 Found waiting player (userId: ${waitingRemotePlayer.playerInfo.userId}), pairing them`
+        );
+        this.game = waitingRemotePlayer.game;
+        this.gameManager.setWaitingRemote(null);
+        this.game.connect(2, { userId: this.userId, username: this.username }, this.connection);
+        this.gameManager.addUserGame(this.userId, this.game);
+        this.game
+          .runGameCountdown()
+          .catch((err) => console.error("Error during online game countdown:", err));
+        console.log(`✅ Game started with opponent`);
+      } else {
+        if (waitingRemotePlayer) {
+          console.log(`⚠️ Waiting player is same user (${this.userId}), creating new game instead`);
+        } else {
+          console.log(`➕ No waiting player, creating new game`);
+        }
+        this.game = createGame(this.mode, (game) => {
+          this.gameManager.removeActiveGame(game);
+          game.clients.forEach((client) => {
+            this.gameManager.removeUserGame(client.playerInfo.userId);
+          });
+        });
+        this.game.connect(1, { userId: this.userId, username: this.username }, this.connection);
+        this.game.freezeBall();
+        this.gameManager.addActiveGame(this.game);
+        this.gameManager.addUserGame(this.userId, this.game);
+        this.gameManager.setWaitingRemote({
+          playerInfo: { userId: this.userId, username: this.username },
+          connection: this.connection,
+          game: this.game,
+        });
+        console.log(`✅ Game created and waiting for opponent`);
+      }
+    } catch (err) {
+      console.error("❌ joinGame error:", err);
+      throw err;
+    }
+  }
+}

--- a/backend_gamelogic/src/connection/RemoteConnection.ts
+++ b/backend_gamelogic/src/connection/RemoteConnection.ts
@@ -41,7 +41,7 @@ export default class RemoteConnection extends ConnectionSession {
     }
   }
 
-  protected onClose() {
+  public onClose() {
     if (this.game) {
       this.game.disconnect(this.connection);
     }

--- a/backend_gamelogic/src/connection/TournamentConnection.ts
+++ b/backend_gamelogic/src/connection/TournamentConnection.ts
@@ -1,0 +1,95 @@
+import ConnectionSession from "./ConnectionSession.js";
+import { Tournament } from "../Tournament.js";
+import { GameManager } from "../gameManager.js";
+import { sendErrorToClient } from "../networkUtils.js";
+import { createGame } from "../gameUtils.js";
+
+export default class TournamentConnection extends ConnectionSession {
+  private tournament: Tournament | null = null;
+  constructor(connection: any, req: any, mode: string, gameManager: GameManager) {
+    super(connection, req, mode, gameManager);
+  }
+
+  protected async handleMessage(data: any) {
+    switch (data.type) {
+      case "newTournament":
+        if (!data.players || !Array.isArray(data.players)) {
+          sendErrorToClient(this.connection, "Invalid players list");
+          return;
+        }
+        if (this.tournament) {
+          this.gameManager.removeTournament(this.tournament);
+          this.tournament = null;
+        }
+        try {
+          this.tournament = new Tournament(this.checkNames(data.players));
+        } catch (err) {
+          sendErrorToClient(this.connection, (err as Error).message);
+          return;
+        }
+        this.gameManager.addTournament(this.tournament);
+        this.startGame();
+        break;
+      case "newGame":
+        if (!this.tournament || !this.game || !this.game.isWaiting) return;
+        this.game.runGameCountdown();
+        break;
+
+      case "nextGame":
+        if (!this.tournament) return;
+        this.startGame();
+        break;
+      default:
+        break;
+    }
+  }
+
+  protected onClose() {
+    this.stopGame();
+    if (this.tournament) {
+      this.gameManager.removeTournament(this.tournament);
+    }
+    this.tournament = null;
+  }
+
+  private checkNames(names: string[]): string[] {
+    const usernames = names.map((name: string) => name.trim());
+    if (usernames.includes("")) throw new Error("Player usernames must be non-empty");
+
+    const uniqueUsernames = new Set(usernames);
+    if (uniqueUsernames.size !== usernames.length)
+      throw new Error("Player usernames must be unique");
+
+    if (names.length !== 4 && names.length !== 8) {
+      throw new Error("Tournament must have exactly 4 or 8 players");
+    }
+    return usernames;
+  }
+
+  private startGame() {
+    if (!this.tournament) return;
+    const pair = this.tournament.getNextPair();
+    if (!pair) {
+      console.log("🏆 No more pairs - tournament complete!");
+      this.tournament.getResults();
+      this.gameManager.removeTournament(this.tournament);
+      this.tournament = null;
+      return;
+    }
+
+    this.game = createGame(this.mode, (game) => {
+      this.gameManager.removeActiveGame(game);
+    });
+    this.game.tournament = this.tournament;
+    this.game.clients.set(1, {
+      playerInfo: { username: pair.player1.username, userId: pair.player1.userId },
+      connection: this.connection,
+    });
+    this.game.clients.set(2, {
+      playerInfo: { username: pair.player2.username, userId: pair.player2.userId },
+      connection: undefined,
+    });
+    this.game.freezeBall();
+    this.gameManager.addActiveGame(this.game);
+  }
+}

--- a/backend_gamelogic/src/connection/TournamentConnection.ts
+++ b/backend_gamelogic/src/connection/TournamentConnection.ts
@@ -44,7 +44,7 @@ export default class TournamentConnection extends ConnectionSession {
     }
   }
 
-  protected onClose() {
+  public onClose() {
     this.stopGame();
     if (this.tournament) {
       this.gameManager.removeTournament(this.tournament);

--- a/backend_gamelogic/src/gameManager.ts
+++ b/backend_gamelogic/src/gameManager.ts
@@ -1,0 +1,107 @@
+import { GameServer, PlayerInfo } from "./gameTypes.js";
+import { Tournament } from "./Tournament.js";
+
+export type WaitingRemote = {
+  playerInfo: PlayerInfo;
+  connection: any;
+  game: GameServer;
+};
+
+export class GameManager {
+  private activeGames = new Set<GameServer>();
+  private activePlayers = new Map<
+    number,
+    { online: GameServer | null; friend: Map<string, GameServer> | null }
+  >();
+  private activeTournaments = new Set<Tournament>();
+  private waitingRemotePlayer: WaitingRemote | null = null;
+
+  addTournament(t: Tournament) {
+    this.activeTournaments.add(t);
+  }
+
+  removeTournament(t: Tournament) {
+    this.activeTournaments.delete(t);
+  }
+  getWaitingRemote() {
+    return this.waitingRemotePlayer;
+  }
+
+  isWaitingRemote(userId: number) {
+    return this.waitingRemotePlayer && this.waitingRemotePlayer.playerInfo.userId === userId;
+  }
+
+  setWaitingRemote(waiting: WaitingRemote | null) {
+    this.waitingRemotePlayer = waiting;
+  }
+
+  addActiveGame(game: GameServer) {
+    this.activeGames.add(game);
+  }
+
+  removeActiveGame(game: GameServer) {
+    this.activeGames.delete(game);
+  }
+
+  addUserGame(userId: number, game: GameServer, gameId?: string) {
+    if (!this.activePlayers.has(userId)) {
+      this.activePlayers.set(userId, { online: null, friend: null });
+    }
+    const playerEntry = this.activePlayers.get(userId);
+    if (!gameId) {
+      playerEntry!.online = game;
+    } else {
+      if (!playerEntry!.friend) {
+        playerEntry!.friend = new Map<string, GameServer>();
+      }
+      playerEntry!.friend.set(gameId, game);
+    }
+  }
+
+  removeUserGame(userId: number, gameId?: string) {
+    const playerEntry = this.activePlayers.get(userId);
+    if (!playerEntry) return;
+
+    if (!gameId) {
+      playerEntry.online = null;
+    } else {
+      playerEntry.friend?.delete(gameId!);
+      if (playerEntry.friend?.size === 0) {
+        playerEntry.friend = null;
+      }
+    }
+    if (!playerEntry.online && !playerEntry.friend) {
+      this.activePlayers.delete(userId);
+    }
+  }
+
+  getUserGame(userId: number, gameId?: string): GameServer | null {
+    const playerEntry = this.activePlayers.get(userId);
+    if (!playerEntry) return null;
+
+    if (!gameId) {
+      return playerEntry.online;
+    } else if (playerEntry.friend) {
+      return playerEntry.friend.get(gameId) || null;
+    }
+    return null;
+  }
+
+  stopAllGames() {
+    this.activeGames.forEach((game) => {
+      try {
+        game.stop();
+      } catch (err) {
+        console.error("Error stopping game:", err);
+      }
+    });
+    this.activeGames.clear();
+    this.activePlayers.clear();
+    this.waitingRemotePlayer = null;
+    this.activeTournaments.clear();
+  }
+
+  getActiveGames() {
+    return this.activeGames;
+  }
+}

--- a/backend_gamelogic/src/gameUtils.ts
+++ b/backend_gamelogic/src/gameUtils.ts
@@ -72,12 +72,15 @@ async function sendMatchResult(game: GameServer): Promise<void> {
 }
 
 // Factory function to create game with specified mode
-export function createGame(gameMode: string): GameServer {
+export function createGame(gameMode: string, onGameEnd?: (game: GameServer) => void): GameServer {
   const game = new GameServer(gameMode);
 
   // Set up callbacks
   game.setUpdateCallback(updateGameState);
   game.setRenderCallback(broadcastGameState);
+  if (onGameEnd) {
+    game.setCleanupCallback(onGameEnd);
+  }
 
   return game;
 }
@@ -218,7 +221,7 @@ export function updateGameState(game: GameServer) {
 
     // Broadcast game result to clients (they will send nextGame acknowledgement)
     broadcastGameResult(game);
-
+    game.invokeCleanup();
     return;
   }
 

--- a/backend_gamelogic/src/networkUtils.ts
+++ b/backend_gamelogic/src/networkUtils.ts
@@ -158,6 +158,9 @@ export function broadcastGameResult(game: GameServer) {
 // Helper function to send error message to client
 export function sendErrorToClient(connection: any, error: string) {
   try {
+    if (!connection) {
+      return;
+    }
     connection.send(
       JSON.stringify({
         type: "error",

--- a/backend_gamelogic/src/server.ts
+++ b/backend_gamelogic/src/server.ts
@@ -1,11 +1,15 @@
 import Fastify from "fastify";
 import { FastifyInstance } from "fastify";
 import { config, VALID_MODES, validateConfig } from "./config.js";
-import { createGame } from "./gameUtils.js";
-import { GameServer, GameStartPayload, PlayerInfo } from "./gameTypes.js";
 import { sendErrorToClient } from "./networkUtils.js";
 import errorHandlerPlugin from "./plugins/errorHandlerPlugin.js";
-import { Tournament } from "./Tournament.js";
+import { GameManager } from "./gameManager.js";
+import LocalConnection from "./connection/LocalConnection.js";
+import AIConnection from "./connection/AIConnection.js";
+import RemoteConnection from "./connection/RemoteConnection.js";
+import FriendConnection from "./connection/FriendConnection.js";
+import TournamentConnection from "./connection/TournamentConnection.js";
+import { verifyAccessToken, fetchUsername } from "./utils/authUtils.js";
 
 // Validate configuration on startup
 validateConfig();
@@ -20,29 +24,12 @@ const fastify: FastifyInstance = Fastify({
 await fastify.register(errorHandlerPlugin);
 await fastify.register(import("@fastify/websocket"));
 
-// NOTE: We create one game instance per WebSocket connection.
-// The client will ask to start a new game (via `newGame` message).
-// Track all active games so we can report health and perform graceful shutdown.
-const activeGames = new Set<GameServer>();
-
-// Track active players (userId -> game) to prevent multiple simultaneous games
-// Also enables future functionality to terminate games on user logout
-const activePlayers = new Map<
-  number,
-  { online: GameServer | null; friend: Map<string, GameServer> | null }
->();
-const activeTournaments = new Set<Tournament>();
-
-// Track the single player waiting for an opponent in ONLINE mode
-// Only one player can wait at a time
-let waitingRemotePlayer: {
-  playerInfo: PlayerInfo;
-  connection: any;
-  game: GameServer;
-} | null = null;
+// Create single GameManager instance for all game tracking and lifecycle management
+const gameManager = new GameManager();
 
 // Health check endpoint
 fastify.get("/health", async () => {
+  const activeGames = gameManager.getActiveGames();
   const connectedClients = Array.from(activeGames).reduce((acc, g) => acc + g.clients.size, 0);
   return {
     status: "healthy",
@@ -53,489 +40,143 @@ fastify.get("/health", async () => {
   };
 });
 
-function addGame(userId: number, game: GameServer, gameId?: string) {
-  const user = activePlayers.get(userId);
-  if (!user) {
-    activePlayers.set(
-      userId,
-      !gameId ? { online: game, friend: null } : { online: null, friend: new Map([[gameId, game]]) }
-    );
-    return;
-  }
-  if (!gameId) {
-    user.online = game;
-    return;
-  }
-  if (!user.friend) user.friend = new Map();
-  user.friend.set(gameId, game);
-}
-
-function removeGame(userId: number, gameId?: string) {
-  const user = activePlayers.get(userId);
-  if (!user) return;
-  if (!gameId) user.online = null;
-  else if (user.friend) {
-    user.friend.delete(gameId);
-    if (user.friend.size === 0) {
-      user.friend = null;
-    }
-  }
-  if (!user.online && !user.friend) {
-    activePlayers.delete(userId);
-  }
-}
-function fetchGame(userId: number, gameId?: string): GameServer | null {
-  const userGames = activePlayers.get(userId);
-  if (!userGames) return null;
-  if (!gameId) return userGames.online || null;
-  if (!userGames.friend) return null;
-  return userGames.friend.get(gameId) || null;
-}
-
-function stopGame(game: GameServer | null, connection: any | null): GameServer | null {
-  if (
-    game &&
-    (!connection || Array.from(game.clients.values()).find((c) => c.connection === connection))
-  ) {
-    try {
-      game.stop();
-    } catch (err) {
-      console.error("Error stopping game:", err);
-    }
-    if (["remote", "friend"].includes(game.gameMode)) {
-      game.clients.forEach((client) => {
-        removeGame(client.playerInfo.userId, game?.gameId);
-      });
-    }
-
-    if (waitingRemotePlayer && waitingRemotePlayer.game === game) {
-      waitingRemotePlayer = null;
-    }
-    game.clients.clear();
-    activeGames.delete(game);
-    game = null;
-  }
-  return game;
-}
-
-// Helper function to terminate all games for a specific user (e.g., on logout)
-// Can be called from an HTTP endpoint in the future
-function terminateUserGames(userId: number): void {
-  const user = activePlayers.get(userId);
-  if (!user) return;
-  const userGames = new Set<GameServer>();
-  if (user.online) userGames.add(user.online);
-  if (user.friend) {
-    for (const game of user.friend.values()) {
-      userGames.add(game);
-    }
-  }
-
-  for (const game of userGames) {
-    // Notify clients in the game with different messages
-    game.clients.forEach((client) => {
-      try {
-        if (client.playerInfo && client.playerInfo.userId === userId) {
-          // Message for the user who logged out
-          client.connection.send(
-            JSON.stringify({
-              type: "error",
-              message: "Game terminated: You have been logged out",
-            })
-          );
-        } else {
-          // Message for the opponent
-          client.connection.send(
-            JSON.stringify({
-              type: "error",
-              message: "Game terminated: Opponent logged out",
-            })
-          );
-        }
-      } catch (err) {
-        console.error("Failed to notify client:", err);
-      }
-    });
-    stopGame(game, null);
-  }
-}
-
 // WebSocket route for game
 fastify.register(async function (server: FastifyInstance) {
-  server.get("/game", { websocket: true }, (connection: any, req: any) => {
+  server.get("/game", { websocket: true }, async (connection: any, req: any) => {
     console.log("Client connected");
 
-    // Each connection is assigned a player number and game
-    let game: ReturnType<typeof createGame> | null = null;
-    let tournament: Tournament | null = null;
-    let mode: string | null = null;
-    let player: PlayerInfo | null = null;
-    let gameId: string | null = null;
+    let session: any = null;
+    const messageQueue: any[] = [];
 
-    connection.on("message", async (message: any) => {
+    // Set up message listener IMMEDIATELY before async operations
+    connection.on("message", (raw: any) => {
       try {
-        const data = JSON.parse(message.toString());
-
-        // Handle different message types
-        switch (data.type) {
-          case "playerInput": {
-            if (!game) return;
-            const input = data.data as { player: number; action: string };
-            game.handlePlayerInput(input);
-            break;
-          }
-          case "newGame": {
-            // Validate and extract game mode and player info
-            const gameStartData = data as GameStartPayload;
-            const { error, gameMode, player, difficulty, gameId } =
-              validateNewGameMessage(gameStartData);
-
-            if (error) {
-              console.warn("Invalid newGame message:", error);
-              sendErrorToClient(connection, error);
-              return;
-            }
-            mode = gameMode!;
-
-            const joinGame = () => {
-              if (!game) {
-                game = createGame(mode!);
-                game.clients.set(1, { playerInfo: player!, connection });
-                activeGames.add(game);
-                game.gameId = gameId;
-                addGame(player!.userId, game, gameId);
-                game.freezeBall();
-              } else {
-                game.isWaiting = false;
-                game.clients.set(2, { playerInfo: player!, connection });
-                addGame(player!.userId, game, gameId);
-                game
-                  .runGameCountdown()
-                  .catch((err) => console.error("Error during online game countdown:", err));
-              }
-            };
-
-            if (mode === "tournament") {
-              if (!tournament || !game) return;
-              if (!game.isWaiting) return;
-              game.isWaiting = false;
-              game
-                .runGameCountdown()
-                .catch((err) => console.error("Error during tournament game countdown:", err));
-              break;
-            }
-
-            if (["remote", "friend"].includes(mode)) {
-              game = fetchGame(player!.userId, gameId);
-              if (game && game.updateConnection(player!.userId, connection)) {
-                break;
-              }
-            }
-            game = stopGame(game, connection);
-
-            if (["local", "ai"].includes(mode)) {
-              game = createGame(mode);
-              if (mode === "ai") {
-                game.aiPlayer.aiDifficulty = difficulty!;
-              }
-
-              game.clients.set(2, {
-                playerInfo: { userId: 0, username: mode },
-                connection,
-              });
-              activeGames.add(game);
-              game.freezeBall();
-
-              game
-                .runGameCountdown()
-                .catch((err) => console.error("Error during local game countdown:", err));
-            } else if (mode === "remote") {
-              if (!waitingRemotePlayer) {
-                joinGame();
-                waitingRemotePlayer = { playerInfo: player!, connection, game: game! };
-              } else {
-                game = waitingRemotePlayer.game;
-                waitingRemotePlayer = null;
-                joinGame();
-              }
-            } else if (mode === "friend") {
-              if (!gameId) {
-                const errorMsg = "Missing required field: gameId for friend mode";
-                console.warn("Invalid newGame message:", errorMsg);
-                sendErrorToClient(connection, errorMsg);
-                return;
-              }
-              // Fetch invitation from backend database service using internal endpoint
-              try {
-                const backendUrl = config.backendDatabase.url;
-                const resp = await fetch(`${backendUrl}/api/internal/game-invites/${gameId}`, {
-                  headers: {
-                    "X-Service-Token": config.serviceAuth.secret,
-                  },
-                });
-                if (!resp.ok) {
-                  const msg = await resp.text().catch(() => "");
-                  const errorMsg = "This invitation is no longer valid.";
-                  console.warn("Invalid newGame message:", errorMsg, resp.status, msg);
-                  sendErrorToClient(connection, errorMsg);
-                  return;
-                }
-
-                const json = await resp.json();
-                const invite = json.data;
-                if (!invite) {
-                  const errorMsg = "This invitation is no longer valid.";
-                  console.warn("Invalid newGame message:", errorMsg);
-                  sendErrorToClient(connection, errorMsg);
-                  return;
-                }
-
-                // Validate that the joining player is either inviter or invitee
-                const userId = player!.userId;
-                const invitedIds = [Number(invite.inviter_id), Number(invite.invitee_id)];
-                if (!invitedIds.includes(Number(userId))) {
-                  const errorMsg = "You are not authorized to join this game.";
-                  console.warn("Invalid newGame message:", errorMsg);
-                  sendErrorToClient(connection, errorMsg);
-                  return;
-                }
-
-                for (const id of invitedIds) {
-                  game = fetchGame(id, gameId);
-                  if (game) break;
-                }
-
-                joinGame();
-                if (!game) {
-                  console.error("Failed to create or join friend game");
-                  return;
-                }
-              } catch (err) {
-                console.error("Error fetching invitation from backend:", err);
-                sendErrorToClient(connection, "This invitation is no longer valid.");
-                return;
-              }
-            }
-            break;
-          }
-          case "newTournament": {
-            // Validate and extract game mode and player info (but it will send 4 or 8 playerInfos)
-            const tournamentData = data as {
-              mode: string;
-              players: string[];
-            };
-            const { error, mode, players } = validateTournamentMessage(tournamentData);
-
-            if (error || !players) {
-              const errorMsg = error || "Missing required field: players";
-              console.warn("Invalid newTournament message:", errorMsg);
-              sendErrorToClient(connection, errorMsg);
-              return;
-            }
-
-            if (mode !== "tournament") {
-              const errorMsg = "Game mode must be 'tournament' for newTournament";
-              console.warn("Invalid newTournament message:", errorMsg);
-              sendErrorToClient(connection, errorMsg);
-              return;
-            }
-
-            if (tournament) {
-              activeTournaments.delete(tournament);
-              tournament = null;
-            }
-
-            tournament = new Tournament(players);
-            activeTournaments.add(tournament);
-            game = startNextTournamentGame(connection, tournament);
-            break;
-          }
-          case "nextGame": {
-            if (!data.mode) return;
-            if (
-              (data.mode === "tournament" && tournament) ||
-              ["friend", "remote"].includes(data.mode)
-            ) {
-              game = stopGame(game, null);
-              if (data.mode === "tournament") {
-                game = startNextTournamentGame(connection, tournament);
-                if (!game) {
-                  // send tournament complete message with results
-                  connection.send(
-                    JSON.stringify({
-                      type: "tournamentComplete",
-                      gameMode: data.mode,
-                      results: tournament!.getResults() || [],
-                    })
-                  );
-                  tournament = null;
-                }
-              }
-            }
-            break;
-          }
+        if (session) {
+          session.onMessagePublic(raw);
+        } else {
+          messageQueue.push(raw);
         }
       } catch (err) {
-        console.error("Error parsing message:", err);
-        sendErrorToClient(connection, "Failed to parse message");
+        console.error("❌ Exception in message handler:", err);
       }
     });
 
     connection.on("close", () => {
-      console.log("Client disconnected");
-
-      // Notify other players in the game that someone left
-      if (game && ["remote", "friend"].includes(game.gameMode)) {
-        let leavingClient = Array.from(game.clients.values()).find(
-          (c) => c.connection === connection
-        );
-        if (!leavingClient) return;
-        game = fetchGame(leavingClient.playerInfo.userId, game.gameId);
-        if (!game) return;
-        const connections = Array.from(game.clients.values()).map((c) => c.connection);
-        if (!connections.includes(leavingClient.connection)) return;
-        game.clients.forEach((client) => {
-          if (client.connection !== connection) {
-            try {
-              client.connection.send(
-                JSON.stringify({
-                  type: "playerLeft",
-                  message: "Your opponent has left the game",
-                })
-              );
-            } catch (err) {
-              console.error("Failed to notify client about player leaving:", err);
-            }
-          }
-        });
+      if (session) {
+        try {
+          session.onClosePublic();
+        } catch (err) {
+          console.error("❌ Exception in close handler:", err);
+        }
       }
-      game = stopGame(game, connection);
     });
+
+    connection.on("error", (err: any) => {
+      console.error("❌ WebSocket error event:", err);
+    });
+
+    try {
+      // Extract mode from query parameters
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const mode = url.searchParams.get("mode");
+      const gameId = url.searchParams.get("gameId") || undefined;
+
+      // Validate mode
+      if (!mode || !VALID_MODES.includes(mode)) {
+        sendErrorToClient(
+          connection,
+          `Invalid or missing mode. Must be one of: ${VALID_MODES.join(", ")}`
+        );
+        connection.close();
+        return;
+      }
+      if (["friend"].includes(mode) && !gameId) {
+        sendErrorToClient(connection, "Missing gameId for friend mode");
+        connection.close();
+        return;
+      }
+
+      let userId: number | undefined;
+      let username: string | undefined;
+      let token: string | undefined;
+
+      if (["remote", "friend"].includes(mode)) {
+        token = url.searchParams.get("token") || undefined;
+
+        if (!token) {
+          sendErrorToClient(connection, "Missing authentication token for authenticated mode");
+          connection.close();
+          return;
+        }
+
+        try {
+          userId = await verifyAccessToken(token);
+
+          // Fetch username from database
+          username = await fetchUsername(userId, token);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : "Token verification failed";
+          sendErrorToClient(connection, `Authentication failed: ${errorMessage}`);
+          connection.close();
+          return;
+        }
+      }
+
+      try {
+        switch (mode) {
+          case "local":
+            session = new LocalConnection(connection, req, mode, gameManager);
+            break;
+          case "ai":
+            session = new AIConnection(connection, req, mode, gameManager);
+            break;
+          case "remote":
+            session = new RemoteConnection(connection, req, mode, gameManager, userId!, username!);
+            break;
+          case "friend":
+            session = new FriendConnection(
+              connection,
+              req,
+              mode,
+              gameManager,
+              userId!,
+              username!,
+              gameId!
+            );
+            break;
+          case "tournament":
+            session = new TournamentConnection(connection, req, mode, gameManager);
+            break;
+          default:
+            break;
+        }
+      } catch (err) {
+        console.error(`❌ Error creating session for ${mode}:`, err);
+        throw err;
+      }
+      // Process any queued messages
+      if (messageQueue.length > 0) {
+        for (const queuedMessage of messageQueue) {
+          try {
+            await session.onMessagePublic(queuedMessage);
+          } catch (err) {
+            console.error("❌ Error processing queued message:", err);
+          }
+        }
+        messageQueue.length = 0;
+      }
+    } catch (err) {
+      console.error("❌ WebSocket handler error:", err);
+      try {
+        sendErrorToClient(
+          connection,
+          `Server error: ${err instanceof Error ? err.message : "Unknown error"}`
+        );
+      } catch (e) {}
+      connection.close();
+    }
   });
 });
-
-function startNextTournamentGame(
-  connection: any,
-  tournament?: Tournament | null
-): GameServer | null {
-  if (!tournament) return null;
-  const pair = tournament.getNextPair();
-  if (!pair) {
-    console.log("🏆 No more pairs - tournament complete!");
-    tournament.getResults();
-    //send results
-    activeTournaments.delete(tournament);
-    tournament = null;
-    return null;
-  }
-
-  const game = createGame("tournament");
-  game.tournament = tournament;
-  game.clients.set(1, {
-    playerInfo: { username: pair.player1.username, userId: pair.player1.userId },
-    connection,
-  });
-  game.clients.set(2, {
-    playerInfo: { username: pair.player2.username, userId: pair.player2.userId },
-    connection: undefined,
-  });
-  activeGames.add(game);
-  game.freezeBall();
-  return game;
-}
-
-// Helper function to validate newGame message
-function validateNewGameMessage(data: any): {
-  error?: string;
-  gameMode?: string;
-  player?: PlayerInfo;
-  difficulty?: "easy" | "medium" | "hard";
-  gameId?: string;
-} {
-  // Check if mode is present
-  if (!data.mode) {
-    return { error: "Missing required field: mode" };
-  }
-
-  // Validate game mode
-  const validModes = Object.values(VALID_MODES);
-  if (!validModes.includes(data.mode)) {
-    return {
-      error: `Invalid game mode: ${data.mode}. Must be one of: ${validModes.join(", ")}`,
-    };
-  }
-
-  // Validate difficulty if provided
-  if (data.mode === "ai" && !["easy", "medium", "hard"].includes(data.difficulty)) {
-    return {
-      error: `Invalid difficulty: ${data.difficulty}. Must be one of: easy, medium, hard`,
-    };
-  }
-
-  if (["remote", "friend"].includes(data.mode)) {
-    if (!data.player) {
-      return { error: "Missing required field: player" };
-    }
-
-    if (!data.player.username) {
-      return { error: "Player must have a username" };
-    }
-
-    if (!data.player.userId) {
-      return { error: "Player must have a userId" };
-    }
-  }
-  if (data.mode === "friend" && !data.gameId) {
-    return { error: "Missing required field: gameId for friend mode" };
-  }
-
-  return {
-    gameMode: data.mode,
-    player: data.player,
-    difficulty: data.difficulty,
-    gameId: data.gameId,
-  };
-}
-
-function validateTournamentMessage(data: any): {
-  error?: string;
-  mode?: string;
-  players?: string[];
-} {
-  // Check if mode is present
-  if (!data.mode) {
-    return { error: "Missing required field: mode" };
-  }
-  if (data.mode !== "tournament") {
-    return { error: "Game mode must be 'tournament' for newTournament" };
-  }
-
-  if (!data.players) {
-    return { error: "Missing or invalid required field: players" };
-  }
-
-  // Additional validation: check for unique and non-empty usernames
-  const usernames = data.players.map((name: string) => name.trim());
-  const uniqueUsernames = new Set(usernames);
-
-  if (usernames.includes("")) {
-    return { error: "Player usernames must be non-empty" };
-  }
-
-  if (uniqueUsernames.size !== usernames.length) {
-    return { error: "Player usernames must be unique" };
-  }
-
-  //Check if there are 4 or 8 players
-  if (data.players.length !== 4 && data.players.length !== 8) {
-    return { error: "Tournament must have exactly 4 or 8 players" };
-  }
-
-  return {
-    mode: data.mode,
-    players: data.players,
-  };
-}
 
 // Start server
 fastify.listen(
@@ -556,20 +197,9 @@ fastify.listen(
 );
 
 // Graceful shutdown
-const stopAllGames = () => {
-  for (const g of Array.from(activeGames)) {
-    try {
-      g.stop();
-    } catch (err) {
-      console.error("Error stopping game during shutdown:", err);
-    }
-    activeGames.delete(g);
-  }
-};
-
 process.on("SIGTERM", () => {
   console.log("🛑 Shutting down gracefully...");
-  stopAllGames();
+  gameManager.stopAllGames();
   fastify.close(() => {
     console.log("✅ Server closed");
     process.exit(0);
@@ -578,7 +208,7 @@ process.on("SIGTERM", () => {
 
 process.on("SIGINT", () => {
   console.log("\n🛑 Shutting down gracefully...");
-  stopAllGames();
+  gameManager.stopAllGames();
   fastify.close(() => {
     console.log("✅ Server closed");
     process.exit(0);

--- a/backend_gamelogic/src/utils/authUtils.ts
+++ b/backend_gamelogic/src/utils/authUtils.ts
@@ -40,6 +40,9 @@ export async function verifyAccessToken(token: string): Promise<number> {
     }
 
     const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"));
+    if (!payload.sub) {
+      throw new Error("Token missing user ID claim");
+    }
     const userId = parseInt(payload.sub);
 
     if (isNaN(userId)) {

--- a/backend_gamelogic/src/utils/authUtils.ts
+++ b/backend_gamelogic/src/utils/authUtils.ts
@@ -1,0 +1,91 @@
+import { config } from "../config.js";
+//TODO: Silas please check if I need this whole file or if there is anything I could reuse
+// I know skill issue, but please, thanks
+
+/**
+ * Verifies an access token by calling the backend database service
+ * Returns userId if token is valid
+ * @throws Error if token is invalid, expired, or verification fails
+ */
+export async function verifyAccessToken(token: string): Promise<number> {
+  try {
+    // Call backend_database to verify token using Bearer header
+    const verifyUrl = `${config.backendDatabase.url}${config.backendDatabase.authPrefix}/verify`;
+    console.log(`🔐 Verifying token at: ${verifyUrl}`);
+
+    const response = await fetch(verifyUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.message || "Token verification failed");
+    }
+
+    const data = await response.json();
+
+    if (!data.success) {
+      throw new Error("Token verification failed");
+    }
+
+    // We need to extract userId from the token ourselves since the endpoint doesn't return it
+    // Parse the JWT payload (doesn't require signature verification since we just verified it)
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      throw new Error("Invalid token format");
+    }
+
+    const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"));
+    const userId = parseInt(payload.sub);
+
+    if (isNaN(userId)) {
+      throw new Error("Invalid user ID in token");
+    }
+
+    return userId;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Token verification failed: ${error.message}`);
+    }
+    throw new Error("Token verification failed");
+  }
+}
+
+/**
+ * Fetches username from the database service using the access token for authentication
+ */
+export async function fetchUsername(userId: number, token: string): Promise<string> {
+  try {
+    const usersUrl = `${config.backendDatabase.url}${config.backendDatabase.apiPrefix}/users/${userId}`;
+    console.log(`👤 Fetching username from: ${usersUrl}`);
+
+    const response = await fetch(usersUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch user data: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    if (!data.success || !data.data?.username) {
+      throw new Error("Invalid response format from database service");
+    }
+
+    return data.data.username;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to fetch username: ${error.message}`);
+    }
+    throw new Error("Failed to fetch username");
+  }
+}

--- a/backend_gamelogic/tests/aiOpponent.test.ts
+++ b/backend_gamelogic/tests/aiOpponent.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { GameServer } from "../src/gameTypes.js";
+import { updateDummyPaddle } from "../src/opponent/opponent.js";
+import { predictInterceptionPoint, getErrorConfig } from "../src/opponent/opponent.utils.js";
+import { createGame } from "../src/gameUtils.js";
+
+describe("AI Opponent Logic", () => {
+  let game: GameServer;
+
+  beforeEach(() => {
+    game = createGame("ai");
+    // Reset AI state
+    game.aiPlayer.aiLastDecisionTime = 0;
+    game.aiPlayer.aiTargetY = null;
+    game.isServe = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Configuration", () => {
+    it("should return correct error config for difficulties", () => {
+      const easy = getErrorConfig("easy");
+      const medium = getErrorConfig("medium");
+      const hard = getErrorConfig("hard");
+
+      expect(easy.reactionTime).toBeGreaterThan(medium.reactionTime);
+      expect(medium.reactionTime).toBeGreaterThan(hard.reactionTime);
+
+      expect(easy.positionError).toBeGreaterThan(medium.positionError);
+      expect(hard.positionError).toBeLessThan(medium.positionError);
+    });
+  });
+
+  describe("Prediction Logic", () => {
+    it("should return center when ball is moving away", () => {
+      game.Ball.x = game.Field.width / 2;
+      game.Ball.speedX = -5; // Moving left (away from AI on right)
+
+      const prediction = predictInterceptionPoint(game, 2);
+      expect(prediction).toBe(game.Field.height / 2);
+    });
+
+    it("should predict direct interception correctly", () => {
+      // Ball moving straight right
+      game.Ball.x = game.Field.width / 2;
+      game.Ball.y = game.Field.height / 2;
+      game.Ball.speedX = 10;
+      game.Ball.speedY = 0;
+
+      const prediction = predictInterceptionPoint(game, 2);
+      expect(prediction).toBe(game.Field.height / 2);
+    });
+
+    it("should predict interception with wall bounce", () => {
+      // Setup ball to bounce off bottom wall
+      game.Ball.x = game.Field.width / 2;
+      game.Ball.y = game.Field.height - 50;
+      game.Ball.speedX = 10;
+      game.Ball.speedY = 10; // Moving down-right
+
+      const prediction = predictInterceptionPoint(game, 2);
+
+      // It should bounce and end up higher than the bounce point
+      expect(prediction).toBeLessThan(game.Field.height);
+      expect(prediction).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Decision Making", () => {
+    it("should not update target before reaction time elapses", () => {
+      game.aiPlayer.aiDifficulty = "hard"; // 1000ms reaction
+      game.aiPlayer.aiLastDecisionTime = Date.now(); // Just updated
+      game.aiPlayer.aiTargetY = 100;
+
+      updateDummyPaddle(game, 2);
+
+      // Should not have changed
+      expect(game.aiPlayer.aiTargetY).toBe(100);
+    });
+
+    it("should update target after reaction time elapses", () => {
+      game.aiPlayer.aiDifficulty = "hard";
+      game.aiPlayer.aiLastDecisionTime = Date.now() - 2000; // Long ago
+      game.aiPlayer.aiTargetY = null;
+
+      updateDummyPaddle(game, 2);
+
+      expect(game.aiPlayer.aiTargetY).not.toBeNull();
+      // Should update timestamp
+      expect(game.aiPlayer.aiLastDecisionTime).toBeCloseTo(Date.now(), -2); // Within 100ms
+    });
+
+    it("should force update on serve", () => {
+      game.isServe = true;
+      game.aiPlayer.aiLastDecisionTime = Date.now(); // Just updated, normally would wait
+      game.aiPlayer.aiTargetY = null;
+
+      updateDummyPaddle(game, 2);
+
+      expect(game.aiPlayer.aiTargetY).not.toBeNull();
+      expect(game.isServe).toBe(false); // Should reset flag
+    });
+
+    it("should apply error to prediction", () => {
+      // Mock random to return specific error
+      // First call is chanceToExtraError (return 1 to fail check)
+      // Second call is error direction/magnitude (return 0.5 for max positive error)
+      const randomSpy = vi.spyOn(Math, "random");
+      randomSpy.mockReturnValueOnce(1.0).mockReturnValueOnce(0.9);
+
+      game.aiPlayer.aiDifficulty = "hard";
+      game.aiPlayer.aiLastDecisionTime = 0;
+
+      // Perfect prediction would be center
+      game.Ball.y = game.Field.height / 2;
+      game.Ball.speedY = 0;
+      game.Ball.speedX = 10;
+
+      updateDummyPaddle(game, 2);
+
+      const perfectY = game.Field.height / 2;
+      expect(game.aiPlayer.aiTargetY).not.toBe(perfectY);
+    });
+  });
+
+  describe("Movement Execution", () => {
+    it("should move paddle towards target", () => {
+      game.aiPlayer.aiTargetY = 500;
+      game.Paddle2.cy = 100; // Far above target
+
+      // Force update to skip decision logic and go to movement
+      // We can just call updateDummyPaddle, but we need to make sure it doesn't reset target
+      // So we set lastDecisionTime to now
+      game.aiPlayer.aiLastDecisionTime = Date.now();
+
+      updateDummyPaddle(game, 2);
+
+      expect(game.Paddle2.ySpeed).toBeGreaterThan(0); // Should move down (positive Y)
+    });
+
+    it("should stop when inside deadzone", () => {
+      game.aiPlayer.aiTargetY = 300;
+      game.Paddle2.cy = 305; // Very close
+      game.aiPlayer.aiLastDecisionTime = Date.now();
+
+      updateDummyPaddle(game, 2);
+
+      expect(game.Paddle2.ySpeed).toBe(0);
+    });
+  });
+});

--- a/backend_gamelogic/tests/gameManager.test.ts
+++ b/backend_gamelogic/tests/gameManager.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GameManager } from "../src/gameManager.js";
+import { GameServer, PlayerInfo } from "../src/gameTypes.js";
+import { Tournament } from "../src/Tournament.js";
+import { createGame } from "../src/gameUtils.js";
+
+describe("GameManager", () => {
+  let gameManager: GameManager;
+
+  beforeEach(() => {
+    gameManager = new GameManager();
+  });
+
+  describe("Active Games Management", () => {
+    it("should add an active game", () => {
+      const game = createGame("local");
+      gameManager.addActiveGame(game);
+
+      expect(gameManager.getActiveGames().has(game)).toBe(true);
+      expect(gameManager.getActiveGames().size).toBe(1);
+    });
+
+    it("should remove an active game", () => {
+      const game = createGame("local");
+      gameManager.addActiveGame(game);
+      gameManager.removeActiveGame(game);
+
+      expect(gameManager.getActiveGames().has(game)).toBe(false);
+      expect(gameManager.getActiveGames().size).toBe(0);
+    });
+
+    it("should handle multiple active games", () => {
+      const game1 = createGame("local");
+      const game2 = createGame("ai");
+      const game3 = createGame("remote");
+
+      gameManager.addActiveGame(game1);
+      gameManager.addActiveGame(game2);
+      gameManager.addActiveGame(game3);
+
+      expect(gameManager.getActiveGames().size).toBe(3);
+      expect(gameManager.getActiveGames().has(game1)).toBe(true);
+      expect(gameManager.getActiveGames().has(game2)).toBe(true);
+      expect(gameManager.getActiveGames().has(game3)).toBe(true);
+    });
+  });
+
+  describe("User Game Tracking", () => {
+    it("should add an online game for a user", () => {
+      const game = createGame("local");
+      const userId = 123;
+
+      gameManager.addUserGame(userId, game);
+
+      expect(gameManager.getUserGame(userId)).toBe(game);
+    });
+
+    it("should add a friend game for a user", () => {
+      const game = createGame("friend");
+      const userId = 123;
+      const gameId = "friend-game-1";
+
+      gameManager.addUserGame(userId, game, gameId);
+
+      expect(gameManager.getUserGame(userId, gameId)).toBe(game);
+    });
+
+    it("should return null for non-existent user game", () => {
+      expect(gameManager.getUserGame(999)).toBeNull();
+    });
+
+    it("should handle multiple friend games for one user", () => {
+      const game1 = createGame("friend");
+      const game2 = createGame("friend");
+      const userId = 123;
+
+      gameManager.addUserGame(userId, game1, "game-1");
+      gameManager.addUserGame(userId, game2, "game-2");
+
+      expect(gameManager.getUserGame(userId, "game-1")).toBe(game1);
+      expect(gameManager.getUserGame(userId, "game-2")).toBe(game2);
+    });
+
+    it("should remove a user game", () => {
+      const game = createGame("local");
+      const userId = 123;
+
+      gameManager.addUserGame(userId, game);
+      gameManager.removeUserGame(userId);
+
+      expect(gameManager.getUserGame(userId)).toBeNull();
+    });
+
+    it("should remove a specific friend game", () => {
+      const game1 = createGame("friend");
+      const game2 = createGame("friend");
+      const userId = 123;
+
+      gameManager.addUserGame(userId, game1, "game-1");
+      gameManager.addUserGame(userId, game2, "game-2");
+      gameManager.removeUserGame(userId, "game-1");
+
+      expect(gameManager.getUserGame(userId, "game-1")).toBeNull();
+      expect(gameManager.getUserGame(userId, "game-2")).toBe(game2);
+    });
+  });
+
+  describe("Tournament Management", () => {
+    it("should add and remove a tournament", () => {
+      const tournament = new Tournament(["Player1", "Player2", "Player3", "Player4"]);
+
+      // We can't verify internal state directly without a getter,
+      // but we can ensure it doesn't throw
+      expect(() => gameManager.addTournament(tournament)).not.toThrow();
+      expect(() => gameManager.removeTournament(tournament)).not.toThrow();
+    });
+  });
+
+  describe("Waiting Remote Player Management", () => {
+    it("should set and get waiting remote player", () => {
+      const game = createGame("remote");
+      const playerInfo: PlayerInfo = {
+        userId: 123,
+        username: "TestPlayer",
+      };
+      const connection = { id: "conn-1" };
+
+      const waiting = { playerInfo, connection, game };
+      gameManager.setWaitingRemote(waiting);
+
+      expect(gameManager.getWaitingRemote()).toBe(waiting);
+    });
+
+    it("should check if user is waiting remote", () => {
+      const game = createGame("remote");
+      const playerInfo: PlayerInfo = {
+        userId: 123,
+        username: "TestPlayer",
+      };
+      const connection = { id: "conn-1" };
+
+      gameManager.setWaitingRemote({ playerInfo, connection, game });
+
+      expect(gameManager.isWaitingRemote(123)).toBe(true);
+      expect(gameManager.isWaitingRemote(456)).toBe(false);
+    });
+
+    it("should clear waiting remote player", () => {
+      const game = createGame("remote");
+      const playerInfo: PlayerInfo = {
+        userId: 123,
+        username: "TestPlayer",
+      };
+      const connection = { id: "conn-1" };
+
+      gameManager.setWaitingRemote({ playerInfo, connection, game });
+      gameManager.setWaitingRemote(null);
+
+      expect(gameManager.getWaitingRemote()).toBeNull();
+    });
+  });
+
+  describe("Stop All Games", () => {
+    it("should stop all active games", () => {
+      const game1 = createGame("local");
+      const game2 = createGame("ai");
+
+      const stopSpy1 = vi.spyOn(game1, "stop");
+      const stopSpy2 = vi.spyOn(game2, "stop");
+
+      gameManager.addActiveGame(game1);
+      gameManager.addActiveGame(game2);
+
+      gameManager.stopAllGames();
+
+      expect(stopSpy1).toHaveBeenCalled();
+      expect(stopSpy2).toHaveBeenCalled();
+      expect(gameManager.getActiveGames().size).toBe(0);
+    });
+
+    it("should handle errors when stopping games", () => {
+      const game = createGame("local");
+      game.stop = vi.fn(() => {
+        throw new Error("Stop failed");
+      });
+
+      gameManager.addActiveGame(game);
+
+      // Should not throw, should catch error
+      expect(() => gameManager.stopAllGames()).not.toThrow();
+    });
+
+    it("should clear all data when stopping all games", () => {
+      const game = createGame("local");
+      const playerInfo: PlayerInfo = { userId: 123, username: "Player" };
+      const connection = { id: "conn-1" };
+
+      gameManager.addActiveGame(game);
+      gameManager.addUserGame(123, game);
+      gameManager.setWaitingRemote({ playerInfo, connection, game });
+
+      const tournament = new Tournament(["P1", "P2", "P3", "P4"]);
+      gameManager.addTournament(tournament);
+
+      vi.spyOn(game, "stop");
+
+      gameManager.stopAllGames();
+
+      expect(gameManager.getActiveGames().size).toBe(0);
+      expect(gameManager.getUserGame(123)).toBeNull();
+      expect(gameManager.getWaitingRemote()).toBeNull();
+    });
+  });
+});

--- a/backend_gamelogic/tests/gameServer.test.ts
+++ b/backend_gamelogic/tests/gameServer.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { GameServer, PlayerInfo } from "../src/gameTypes.js";
+import { createGame } from "../src/gameUtils.js";
+
+describe("GameServer Lifecycle", () => {
+  let game: GameServer;
+
+  beforeEach(() => {
+    game = createGame("local");
+  });
+
+  afterEach(() => {
+    game.stop();
+  });
+
+  describe("Game Initialization", () => {
+    it("should create game with correct mode", () => {
+      const localGame = createGame("local");
+      const aiGame = createGame("ai");
+      const remoteGame = createGame("remote");
+      const friendGame = createGame("friend");
+      const tournamentGame = createGame("tournament");
+
+      expect(localGame.gameMode).toBe("local");
+      expect(aiGame.gameMode).toBe("ai");
+      expect(remoteGame.gameMode).toBe("remote");
+      expect(friendGame.gameMode).toBe("friend");
+      expect(tournamentGame.gameMode).toBe("tournament");
+    });
+
+    it("should initialize field and game objects", () => {
+      expect(game.Field).toBeDefined();
+      expect(game.Ball).toBeDefined();
+      expect(game.Paddle1).toBeDefined();
+      expect(game.Paddle2).toBeDefined();
+    });
+
+    it("should initialize scores to zero", () => {
+      expect(game.score1).toBe(0);
+      expect(game.score2).toBe(0);
+    });
+
+    it("should initialize countdown to zero", () => {
+      expect(game.countdown).toBe(0);
+    });
+
+    it("should set waiting flag for remote modes", () => {
+      const localGame = createGame("local");
+      const aiGame = createGame("ai");
+      const remoteGame = createGame("remote");
+      const friendGame = createGame("friend");
+      const tournamentGame = createGame("tournament");
+
+      expect(localGame.isWaiting).toBe(false);
+      expect(aiGame.isWaiting).toBe(false);
+      expect(remoteGame.isWaiting).toBe(true);
+      expect(friendGame.isWaiting).toBe(true);
+      expect(tournamentGame.isWaiting).toBe(true);
+    });
+
+    it("should start with isRunning false", () => {
+      expect(game.running()).toBe(false);
+    });
+
+    it("should initialize empty clients map", () => {
+      expect(game.clients.size).toBe(0);
+      expect(game.clients instanceof Map).toBe(true);
+    });
+  });
+
+  describe("Callback Configuration", () => {
+    it("should set update callback", () => {
+      const callback = vi.fn();
+      game.setUpdateCallback(callback);
+
+      // Callback is stored but not invoked until game starts
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("should set render callback", () => {
+      const callback = vi.fn();
+      game.setRenderCallback(callback);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("should set cleanup callback", () => {
+      const callback = vi.fn();
+      game.setCleanupCallback(callback);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("should throw error if starting without callbacks", () => {
+      const newGame = new GameServer("local");
+
+      expect(() => newGame.start()).toThrow(
+        "Callbacks not set. Call setUpdateCallback() and setRenderCallback() first."
+      );
+    });
+  });
+
+  describe("Game Loops", () => {
+    it("should start physics and render loops", () => {
+      const updateCallback = vi.fn();
+      const renderCallback = vi.fn();
+
+      game.setUpdateCallback(updateCallback);
+      game.setRenderCallback(renderCallback);
+      game.start();
+
+      expect(game.running()).toBe(true);
+    });
+
+    it("should call callbacks when running", async () => {
+      const updateCallback = vi.fn();
+      const renderCallback = vi.fn();
+
+      game.setUpdateCallback(updateCallback);
+      game.setRenderCallback(renderCallback);
+      game.start();
+
+      // Wait for callbacks to be called
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(updateCallback).toHaveBeenCalled();
+      expect(renderCallback).toHaveBeenCalled();
+    });
+
+    it("should warn if starting already running game", () => {
+      const callback = vi.fn();
+      game.setUpdateCallback(callback);
+      game.setRenderCallback(callback);
+
+      const warnSpy = vi.spyOn(console, "warn");
+
+      game.start();
+      game.start();
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls[0][0]).toContain("already running");
+
+      warnSpy.mockRestore();
+    });
+
+    it("should stop physics and render loops", () => {
+      const callback = vi.fn();
+      game.setUpdateCallback(callback);
+      game.setRenderCallback(callback);
+
+      game.start();
+      expect(game.running()).toBe(true);
+
+      game.stop();
+      expect(game.running()).toBe(false);
+    });
+
+    it("should warn if stopping non-running game", () => {
+      const warnSpy = vi.spyOn(console, "warn");
+
+      game.stop();
+
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("should clean up intervals on stop", () => {
+      const callback = vi.fn();
+      game.setUpdateCallback(callback);
+      game.setRenderCallback(callback);
+      game.setCleanupCallback(callback);
+
+      game.start();
+      const callCountBefore = callback.mock.calls.length;
+      game.stop();
+
+      // After stop, game should not be running
+      expect(game.running()).toBe(false);
+    });
+  });
+
+  describe("Player Connections", () => {
+    it("should connect players", () => {
+      const player1Info: PlayerInfo = { userId: 1, username: "Alice" };
+      const player2Info: PlayerInfo = { userId: 2, username: "Bob" };
+      const conn1 = { id: "conn1" };
+      const conn2 = { id: "conn2" };
+
+      game.connect(1, player1Info, conn1);
+      game.connect(2, player2Info, conn2);
+
+      expect(game.clients.size).toBe(2);
+      expect(game.clients.get(1)?.playerInfo).toBe(player1Info);
+      expect(game.clients.get(2)?.playerInfo).toBe(player2Info);
+    });
+
+    it("should check if connection is connected", () => {
+      const playerInfo: PlayerInfo = { userId: 1, username: "Alice" };
+      const conn1 = { id: "conn1" };
+      const conn2 = { id: "conn2" };
+
+      game.connect(1, playerInfo, conn1);
+
+      expect(game.isConnected(conn1)).toBe(true);
+      expect(game.isConnected(conn2)).toBe(false);
+    });
+
+    it("should disconnect by connection object", () => {
+      const playerInfo: PlayerInfo = { userId: 1, username: "Alice" };
+      const conn = { id: "conn1", close: vi.fn(), send: vi.fn() };
+
+      game.connect(1, playerInfo, conn);
+      game.disconnect(conn);
+
+      expect(game.clients.get(1)?.connection).toBeNull();
+    });
+
+    it("should disconnect by userId", () => {
+      const playerInfo: PlayerInfo = { userId: 1, username: "Alice" };
+      const conn = { id: "conn1", close: vi.fn(), send: vi.fn() };
+
+      game.connect(1, playerInfo, conn);
+      game.disconnectByUserId(1);
+
+      expect(game.clients.get(1)?.connection).toBeNull();
+    });
+
+    it("should count connected players", () => {
+      const player1: PlayerInfo = { userId: 1, username: "Alice" };
+      const player2: PlayerInfo = { userId: 2, username: "Bob" };
+      const conn1 = { id: "conn1", send: vi.fn() };
+      const conn2 = { id: "conn2", send: vi.fn() };
+
+      game.connect(1, player1, conn1);
+      game.connect(2, player2, conn2);
+
+      expect(game.connectionCount()).toBe(2);
+
+      game.disconnect(conn1);
+      expect(game.connectionCount()).toBe(1);
+    });
+
+    it("should update connection for existing player", () => {
+      const playerInfo: PlayerInfo = { userId: 1, username: "Alice" };
+      const oldConn = {
+        id: "old",
+        close: vi.fn(),
+        send: vi.fn(),
+        readyState: 1, // WebSocket.OPEN
+      };
+      const newConn = {
+        id: "new",
+        send: vi.fn(),
+        readyState: 1,
+      };
+
+      game.connect(1, playerInfo, oldConn);
+
+      const updated = game.updateConnection(1, newConn);
+
+      expect(updated).toBe(true);
+      // updateConnection may cause broadcast which could fail and remove client
+      // So just verify the return value is correct
+    });
+    it("should return false when updating non-existent player", () => {
+      const newConn = { id: "new" };
+
+      const updated = game.updateConnection(999, newConn);
+
+      expect(updated).toBe(false);
+    });
+  });
+
+  describe("Game Result", () => {
+    it("should return null when players not connected", () => {
+      const result = game.getResult();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return result when both players connected", () => {
+      const player1: PlayerInfo = { userId: 1, username: "Alice" };
+      const player2: PlayerInfo = { userId: 2, username: "Bob" };
+
+      game.connect(1, player1, { id: "1" });
+      game.connect(2, player2, { id: "2" });
+
+      game.score1 = 5;
+      game.score2 = 3;
+
+      const result = game.getResult();
+
+      expect(result).not.toBeNull();
+      expect(result!.winner).toBe(player1);
+      expect(result!.loser).toBe(player2);
+      expect(result!.winnerScore).toBe(5);
+      expect(result!.loserScore).toBe(3);
+    });
+
+    it("should determine winner correctly", () => {
+      const player1: PlayerInfo = { userId: 1, username: "Alice" };
+      const player2: PlayerInfo = { userId: 2, username: "Bob" };
+
+      game.connect(1, player1, { id: "1" });
+      game.connect(2, player2, { id: "2" });
+
+      game.score1 = 2;
+      game.score2 = 5;
+
+      const result = game.getResult();
+
+      expect(result!.winner).toBe(player2);
+      expect(result!.loser).toBe(player1);
+    });
+  });
+
+  describe("Player Input Handling", () => {
+    it.each([
+      { player: 1, action: "up", check: (g: GameServer) => g.Paddle1.ySpeed === -g.Paddle1.speed },
+      { player: 1, action: "down", check: (g: GameServer) => g.Paddle1.ySpeed === g.Paddle1.speed },
+      { player: 1, action: "stop", check: (g: GameServer) => g.Paddle1.ySpeed === 0 },
+      { player: 2, action: "up", check: (g: GameServer) => g.Paddle2.ySpeed === -g.Paddle2.speed },
+      { player: 2, action: "down", check: (g: GameServer) => g.Paddle2.ySpeed === g.Paddle2.speed },
+    ])("should handle player $player action $action", ({ player, action, check }) => {
+      // Pre-condition for stop
+      if (action === "stop") {
+        const paddle = player === 1 ? game.Paddle1 : game.Paddle2;
+        paddle.ySpeed = 10;
+      }
+
+      game.handlePlayerInput({ player: player as 1 | 2, action: action as any });
+      expect(check(game)).toBe(true);
+    });
+  });
+
+  describe("Ball Freezing", () => {
+    it("should freeze ball movement", () => {
+      game.Ball.speedX = 5;
+      game.Ball.speedY = 3;
+
+      game.freezeBall();
+
+      expect(game.Ball.speedX).toBe(0);
+      expect(game.Ball.speedY).toBe(0);
+    });
+
+    it("should start game after freezing", () => {
+      game.setUpdateCallback(() => {});
+      game.setRenderCallback(() => {});
+
+      game.freezeBall();
+
+      expect(game.running()).toBe(true);
+    });
+  });
+
+  describe("Game Countdown", () => {
+    it("should run countdown when game starts", async () => {
+      game.setUpdateCallback(() => {});
+      game.setRenderCallback(() => {});
+      game.start();
+
+      await game.runGameCountdown();
+
+      expect(game.countdown).toBe(0);
+      expect(game.isWaiting).toBe(false);
+    });
+
+    it("should set waiting to false after countdown", async () => {
+      game.isWaiting = true;
+      game.setUpdateCallback(() => {});
+      game.setRenderCallback(() => {});
+      game.start();
+
+      await game.runGameCountdown();
+
+      expect(game.isWaiting).toBe(false);
+    });
+
+    it("should break countdown if game stops", async () => {
+      game.setUpdateCallback(() => {});
+      game.setRenderCallback(() => {});
+      game.start();
+
+      // Stop game immediately
+      setTimeout(() => game.stop(), 10);
+
+      await game.runGameCountdown();
+
+      // Countdown should have stopped early
+      expect(game.running()).toBe(false);
+    });
+  });
+
+  describe("Cleanup Callback", () => {
+    it("should invoke cleanup callback", () => {
+      const cleanupCallback = vi.fn();
+      game.setCleanupCallback(cleanupCallback);
+
+      game.invokeCleanup();
+
+      expect(cleanupCallback).toHaveBeenCalledWith(game);
+    });
+  });
+});

--- a/backend_gamelogic/tests/matchResults.test.ts
+++ b/backend_gamelogic/tests/matchResults.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createGame, updateGameState } from "../src/gameUtils.js";
+import { PlayerInfo } from "../src/gameTypes.js";
+
+describe("Match Result Reporting", () => {
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("OK"),
+    } as Response);
+
+    // Mock console to keep output clean
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should send match result for remote game when score limit reached", async () => {
+    const game = createGame("remote");
+    const player1: PlayerInfo = { userId: 1, username: "P1" };
+    const player2: PlayerInfo = { userId: 2, username: "P2" };
+
+    // Setup players
+    game.connect(1, player1, { id: "c1" });
+    game.connect(2, player2, { id: "c2" });
+
+    // Set score to win
+    game.score1 = game.maxScore;
+    game.score2 = 0;
+
+    // Trigger update
+    updateGameState(game);
+
+    // Wait for async operations (fetch is called without await in updateGameState)
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/matches"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"winner_id":1'),
+      })
+    );
+  });
+
+  it("should NOT send match result for local game", async () => {
+    const game = createGame("local");
+    game.score1 = game.maxScore;
+
+    updateGameState(game);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should delete friend invite after friend game ends", async () => {
+    const game = createGame("friend");
+    game.gameId = "invite-123";
+    const player1: PlayerInfo = { userId: 1, username: "P1" };
+    const player2: PlayerInfo = { userId: 2, username: "P2" };
+
+    game.connect(1, player1, { id: "c1" });
+    game.connect(2, player2, { id: "c2" });
+
+    game.score1 = game.maxScore;
+
+    updateGameState(game);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should call match result AND delete invite
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    // Check for delete call
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/game-invites/invite-123"),
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("should handle fetch errors gracefully", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("Network error"));
+
+    const game = createGame("remote");
+    const player1: PlayerInfo = { userId: 1, username: "P1" };
+    const player2: PlayerInfo = { userId: 2, username: "P2" };
+    game.connect(1, player1, { id: "c1" });
+    game.connect(2, player2, { id: "c2" });
+    game.score1 = game.maxScore;
+
+    updateGameState(game);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should have logged error but not crashed
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Error sending match result"),
+      expect.any(Error)
+    );
+  });
+
+  it("should log error when server returns non-200 for match result", async () => {
+    // Mock server returning 500 error
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    } as Response);
+
+    const game = createGame("remote");
+    const player1: PlayerInfo = { userId: 1, username: "P1" };
+    const player2: PlayerInfo = { userId: 2, username: "P2" };
+    game.connect(1, player1, { id: "c1" });
+    game.connect(2, player2, { id: "c2" });
+    game.score1 = game.maxScore;
+
+    updateGameState(game);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to save match result: 500 Internal Server Error")
+    );
+  });
+
+  it("should log warning when server returns non-200 for invite deletion", async () => {
+    // First call (POST match) succeeds
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve("OK"),
+    } as Response);
+
+    // Second call (DELETE invite) fails
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Invite not found"),
+    } as Response);
+
+    const game = createGame("friend");
+    game.gameId = "invite-123";
+    const player1: PlayerInfo = { userId: 1, username: "P1" };
+    const player2: PlayerInfo = { userId: 2, username: "P2" };
+    game.connect(1, player1, { id: "c1" });
+    game.connect(2, player2, { id: "c2" });
+    game.score1 = game.maxScore;
+
+    updateGameState(game);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to delete friend invitation invite-123: 404 Invite not found")
+    );
+  });
+});

--- a/backend_gamelogic/tests/physics.test.ts
+++ b/backend_gamelogic/tests/physics.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Field, Ball, Paddle } from "../src/gameTypes.js";
+import { collideBallCapsule, closestPointOnSegment } from "../src/gameUtils.js";
+import { config } from "../src/config.js";
+
+describe("Physics and Collision Detection", () => {
+  let field: Field;
+  let ball: Ball;
+  let paddle: Paddle;
+
+  beforeEach(() => {
+    field = new Field(800, 600);
+    ball = new Ball(field);
+    paddle = new Paddle(1, field, 5);
+  });
+
+  describe("Paddle Movement", () => {
+    it("should move paddle up", () => {
+      const initialY = paddle.cy;
+      paddle.ySpeed = -paddle.speed;
+
+      // Simulate one physics step (simplified)
+      paddle.cy += paddle.ySpeed * 0.016; // ~16ms frame
+
+      expect(paddle.cy).toBeLessThan(initialY);
+    });
+
+    it("should move paddle down", () => {
+      const initialY = paddle.cy;
+      paddle.ySpeed = paddle.speed;
+
+      paddle.cy += paddle.ySpeed * 0.016;
+
+      expect(paddle.cy).toBeGreaterThan(initialY);
+    });
+
+    it("should not move paddle beyond field bounds", () => {
+      const halfLen = paddle.length / 2;
+      paddle.cy = halfLen - 10;
+      paddle.ySpeed = -paddle.speed;
+
+      // Move several times
+      for (let i = 0; i < 100; i++) {
+        paddle.cy += paddle.ySpeed * 0.016;
+        // In real game, there's bound checking
+        paddle.cy = Math.max(halfLen, Math.min(field.height - halfLen, paddle.cy));
+      }
+
+      expect(paddle.cy).toBeGreaterThanOrEqual(halfLen);
+      expect(paddle.cy).toBeLessThanOrEqual(field.height - halfLen);
+    });
+
+    it("should have correct capsule dimensions", () => {
+      const capsule = paddle.getCapsule();
+      const halfLen = paddle.length / 2 - paddle.width / 2;
+
+      expect(capsule.x1).toBe(paddle.cx);
+      expect(capsule.x2).toBe(paddle.cx);
+      expect(capsule.y1).toBe(paddle.cy - halfLen);
+      expect(capsule.y2).toBe(paddle.cy + halfLen);
+      expect(capsule.R).toBe(paddle.width / 2);
+    });
+
+    it("should cache capsule when position doesn't change", () => {
+      const capsule1 = paddle.getCapsule();
+      const y1Before = capsule1.y1;
+
+      // Don't change position
+      const capsule2 = paddle.getCapsule();
+
+      expect(capsule1).toBe(capsule2); // Same object reference
+      expect(capsule2.y1).toBe(y1Before); // Same values
+    });
+
+    it("should update capsule when position changes", () => {
+      paddle.cy = 200;
+      const capsule1 = paddle.getCapsule();
+      const oldY1 = capsule1.y1;
+
+      paddle.cy = 400; // Significantly different position
+      const capsule2 = paddle.getCapsule();
+
+      // y1 should be different after position change
+      expect(capsule2.y1).not.toBe(oldY1);
+      expect(capsule2.y1).toBe(paddle.cy - (paddle.length / 2 - paddle.width / 2));
+    });
+  });
+
+  describe("Ball Physics", () => {
+    it("should have initial speed within expected range", () => {
+      const speed = Math.sqrt(ball.speedX ** 2 + ball.speedY ** 2);
+      expect(speed).toBeCloseTo(config.game.ballSpeed, 1);
+    });
+
+    it("should move ball based on velocity", () => {
+      const initialX = ball.x;
+      const initialY = ball.y;
+
+      ball.x += ball.speedX * 0.016;
+      ball.y += ball.speedY * 0.016;
+
+      expect(ball.x).not.toBe(initialX);
+      expect(ball.y).not.toBe(initialY);
+    });
+
+    it("should have angle within reasonable range", () => {
+      const angle = Math.atan2(ball.speedY, ball.speedX);
+      // Ball angle can be any direction initially, just verify it's a valid number
+      expect(isFinite(angle)).toBe(true);
+      expect(Math.abs(angle)).toBeLessThanOrEqual(Math.PI);
+    });
+  });
+
+  describe("Closest Point on Segment", () => {
+    it("should find closest point on paddle segment", () => {
+      const point = closestPointOnSegment(paddle, ball);
+
+      expect(point).toHaveProperty("x");
+      expect(point).toHaveProperty("y");
+      expect(isFinite(point.x)).toBe(true);
+      expect(isFinite(point.y)).toBe(true);
+    });
+
+    it("should find point within paddle bounds vertically", () => {
+      const capsule = paddle.getCapsule();
+      const point = closestPointOnSegment(paddle, ball);
+
+      expect(point.y).toBeGreaterThanOrEqual(capsule.y1 - 1);
+      expect(point.y).toBeLessThanOrEqual(capsule.y2 + 1);
+    });
+
+    it("should find same x as paddle", () => {
+      const point = closestPointOnSegment(paddle, ball);
+      expect(point.x).toBeCloseTo(paddle.cx, 1);
+    });
+
+    it("should clamp point to segment endpoints", () => {
+      // Move ball far above paddle
+      ball.y = -100;
+      const point = closestPointOnSegment(paddle, ball);
+      const capsule = paddle.getCapsule();
+
+      expect(point.y).toBeGreaterThanOrEqual(capsule.y1 - 1);
+    });
+  });
+
+  describe("Ball-Paddle Collision", () => {
+    it("should detect collision when ball touches paddle", () => {
+      // Position ball near paddle
+      paddle.cy = field.height / 2;
+      ball.x = paddle.cx + 10;
+      ball.y = paddle.cy;
+
+      const collided = collideBallCapsule(paddle, ball);
+      expect(collided).toBe(true);
+    });
+
+    it("should not detect collision when ball is far", () => {
+      ball.x = field.width - 50;
+      ball.y = field.height - 50;
+      paddle.cy = 100;
+
+      const collided = collideBallCapsule(paddle, ball);
+      expect(collided).toBe(false);
+    });
+
+    it("should reflect ball velocity on collision", () => {
+      paddle.cy = field.height / 2;
+      ball.x = paddle.cx + 5;
+      ball.y = paddle.cy;
+
+      const initialSpeedX = ball.speedX;
+      ball.speedX = 5; // Ball moving toward paddle
+
+      collideBallCapsule(paddle, ball);
+
+      // After collision, ball should be reflected (negative speed)
+      expect(ball.speedX).not.toBe(initialSpeedX);
+    });
+
+    it("should not reflect ball moving away from paddle", () => {
+      paddle.cy = field.height / 2;
+      ball.x = paddle.cx + 50; // Position ball far away
+      ball.y = paddle.cy;
+      ball.speedX = -5; // Ball moving away
+
+      const collided = collideBallCapsule(paddle, ball);
+
+      // Ball far away should not collide
+      expect(collided).toBe(false);
+    });
+
+    it("should push ball out of paddle", () => {
+      paddle.cy = field.height / 2;
+      // Position ball overlapping with paddle
+      ball.x = paddle.cx;
+      ball.y = paddle.cy;
+      ball.speedX = 5;
+
+      const positionBefore = { x: ball.x, y: ball.y };
+
+      collideBallCapsule(paddle, ball);
+
+      // Ball should be pushed away
+      const distance = Math.hypot(ball.x - paddle.cx, ball.y - paddle.cy);
+      expect(distance).toBeGreaterThan(0);
+    });
+
+    it("should limit deflection angle to 45 degrees", () => {
+      paddle.cy = field.height / 2;
+      ball.x = paddle.cx + 8;
+      ball.y = paddle.cy;
+      ball.speedX = 6;
+      ball.speedY = 0;
+
+      collideBallCapsule(paddle, ball);
+
+      // After collision, angle should be limited
+      const speed = Math.hypot(ball.speedX, ball.speedY);
+      const angle = Math.atan2(ball.speedY, ball.speedX);
+      const maxAngle = Math.PI / 4; // 45 degrees
+
+      expect(Math.abs(angle)).toBeLessThanOrEqual(maxAngle + 0.1); // Small tolerance
+    });
+  });
+
+  describe("Paddle Positions on Field", () => {
+    it("should place paddle 1 on left side", () => {
+      const p1 = new Paddle(1, field, 5);
+      expect(p1.cx).toBeLessThan(field.width / 2);
+    });
+
+    it("should place paddle 2 on right side", () => {
+      const p2 = new Paddle(2, field, 5);
+      expect(p2.cx).toBeGreaterThan(field.width / 2);
+    });
+
+    it("should place both paddles equidistant from center", () => {
+      const p1 = new Paddle(1, field, 5);
+      const p2 = new Paddle(2, field, 5);
+
+      const p1Distance = Math.abs(p1.cx - field.width / 2);
+      const p2Distance = Math.abs(p2.cx - field.width / 2);
+
+      expect(p1Distance).toBeCloseTo(p2Distance);
+    });
+  });
+});

--- a/backend_gamelogic/tests/tournament.test.ts
+++ b/backend_gamelogic/tests/tournament.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Tournament, TournamentPlayer, GamePairing } from "../src/Tournament.js";
+
+describe("Tournament System", () => {
+  describe("Tournament Initialization", () => {
+    it("should create a tournament with valid players", () => {
+      const tournament = new Tournament(["Alice", "Bob", "Charlie", "David"]);
+
+      expect(tournament).toBeDefined();
+      expect(tournament.getRound()).toBe(0);
+    });
+
+    it("should trim player names", () => {
+      const tournament = new Tournament(["  Alice  ", "Bob  ", "  Charlie"]);
+
+      // Tournament should accept trimmed names without error
+      expect(tournament).toBeDefined();
+    });
+
+    it("should reject empty player names", () => {
+      expect(() => {
+        new Tournament(["Alice", "", "Bob"]);
+      }).toThrow("All player names must be non-empty");
+    });
+
+    it("should reject whitespace-only names", () => {
+      expect(() => {
+        new Tournament(["Alice", "   ", "Bob"]);
+      }).toThrow("All player names must be non-empty");
+    });
+
+    it("should reject duplicate player names", () => {
+      expect(() => {
+        new Tournament(["Alice", "Bob", "Alice"]);
+      }).toThrow("All player names must be unique");
+    });
+
+    it("should accept minimum viable tournament size", () => {
+      const tournament = new Tournament(["Alice", "Bob"]);
+      expect(tournament).toBeDefined();
+    });
+
+    it("should accept large tournament", () => {
+      const players = Array.from({ length: 100 }, (_, i) => `Player${i}`);
+      const tournament = new Tournament(players);
+
+      expect(tournament).toBeDefined();
+    });
+  });
+
+  describe("Player Selection", () => {
+    it("should get random player from active players", () => {
+      const tournament = new Tournament(["Alice", "Bob", "Charlie"]);
+
+      const player = tournament.getRandomPlayer();
+
+      expect(player).not.toBeNull();
+      expect(player!.username).toBeDefined();
+      expect(typeof player!.username).toBe("string");
+    });
+
+    it("should remove player from active set after selection", () => {
+      const tournament = new Tournament(["Alice", "Bob"]);
+
+      const player1 = tournament.getRandomPlayer();
+      const player2 = tournament.getRandomPlayer();
+
+      expect(player1!.username).not.toBe(player2!.username);
+    });
+
+    it("should return null when no players available", () => {
+      const tournament = new Tournament(["Alice", "Bob"]);
+
+      tournament.getRandomPlayer();
+      tournament.getRandomPlayer();
+
+      const player = tournament.getRandomPlayer();
+      expect(player).toBeNull();
+    });
+
+    it("should return the last player when all others are taken", () => {
+      const tournament = new Tournament(["Alice", "Bob", "Charlie"]);
+
+      tournament.getRandomPlayer();
+      tournament.getRandomPlayer();
+
+      // One player should still be available (not null)
+      const player = tournament.getRandomPlayer();
+      expect(player).not.toBeNull();
+
+      // Now no more players
+      const nextPlayer = tournament.getRandomPlayer();
+      expect(nextPlayer).toBeNull();
+    });
+  });
+
+  describe("Pairing Generation", () => {
+    it("should generate pairings from available players", () => {
+      const tournament = new Tournament(["Alice", "Bob", "Charlie", "David"]);
+
+      const pair = tournament.getNextPair();
+
+      expect(pair).not.toBeNull();
+      expect(pair!.player1).toBeDefined();
+      expect(pair!.player2).toBeDefined();
+      expect(pair!.round).toBe(1);
+    });
+
+    it("should assign round number to pairs", () => {
+      const tournament = new Tournament(["A", "B", "C", "D", "E", "F"]);
+
+      const pair1 = tournament.getNextPair();
+      expect(pair1!.round).toBe(1);
+
+      const pair2 = tournament.getNextPair();
+      expect(pair2!.round).toBe(1);
+    });
+
+    it("should not pair a player with themselves", () => {
+      const tournament = new Tournament(["Alice", "Bob", "Charlie", "David"]);
+
+      const pair = tournament.getNextPair();
+
+      expect(pair!.player1.username).not.toBe(pair!.player2.username);
+    });
+
+    it("should generate multiple pairs for tournament", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      const pair1 = tournament.getNextPair();
+      const pair2 = tournament.getNextPair();
+
+      expect(pair1).not.toBeNull();
+      expect(pair2).not.toBeNull();
+      expect(pair1!.player1.username).not.toBe(pair2!.player1.username);
+    });
+
+    it("should return null when not enough players for a pair", () => {
+      const tournament = new Tournament(["Alice", "Bob"]);
+
+      const pair = tournament.getNextPair();
+      expect(pair).not.toBeNull();
+
+      const secondPair = tournament.getNextPair();
+      expect(secondPair).toBeNull();
+    });
+
+    it("should handle odd number of players", () => {
+      const tournament = new Tournament(["A", "B", "C"]);
+
+      const pair = tournament.getNextPair();
+      expect(pair).not.toBeNull();
+
+      const secondPair = tournament.getNextPair();
+      expect(secondPair).toBeNull(); // One player left unpaired
+    });
+  });
+
+  describe("Game Results Processing", () => {
+    it("should store game results", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      const pair = tournament.getNextPair()!;
+      pair.player1.score = 5;
+      pair.player2.score = 3;
+
+      tournament.storeGameResult(pair);
+      const results = tournament.getResults();
+
+      expect(results.length).toBe(1);
+      expect(results[0]).toBe(pair);
+    });
+
+    it("should reset winner score to zero", () => {
+      const tournament = new Tournament(["A", "B"]);
+
+      const pair = tournament.getNextPair()!;
+      pair.player1.score = 10;
+      pair.player2.score = 5;
+
+      tournament.storeGameResult(pair);
+
+      expect(pair.player1.score).toBe(0);
+    });
+
+    it("should advance winner back to active players", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      const pair1 = tournament.getNextPair()!;
+      pair1.player1.score = 5;
+      pair1.player2.score = 2;
+
+      tournament.storeGameResult(pair1);
+
+      const pair2 = tournament.getNextPair()!;
+      expect(pair2).not.toBeNull();
+
+      // Winner (player1) should be available for next round
+      const hasPlayer1 =
+        pair2.player1.username === pair1.player1.username ||
+        pair2.player2.username === pair1.player1.username;
+
+      // If not in this pair, there should be more pairs
+      if (!hasPlayer1) {
+        const pair3 = tournament.getNextPair();
+        // Either player1 is in pair2, or will appear in future pairs
+        expect(pair2 || pair3).not.toBeNull();
+      } else {
+        expect(hasPlayer1).toBe(true);
+      }
+    });
+
+    it("should accumulate multiple results", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      const pair1 = tournament.getNextPair()!;
+      pair1.player1.score = 5;
+      pair1.player2.score = 2;
+      tournament.storeGameResult(pair1);
+
+      const pair2 = tournament.getNextPair()!;
+      pair2.player1.score = 6;
+      pair2.player2.score = 4;
+      tournament.storeGameResult(pair2);
+
+      const results = tournament.getResults();
+      expect(results.length).toBe(2);
+    });
+  });
+
+  describe("Tournament Progression", () => {
+    it("should start at round 0", () => {
+      const tournament = new Tournament(["A", "B"]);
+
+      expect(tournament.getRound()).toBe(0);
+    });
+
+    it("should increment round when new pairings generated", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      tournament.getNextPair();
+      expect(tournament.getRound()).toBe(1);
+    });
+
+    it("should not increment round for same round pairs", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      tournament.getNextPair();
+      const round1 = tournament.getRound();
+
+      tournament.getNextPair();
+      const round2 = tournament.getRound();
+
+      expect(round2).toBe(round1);
+    });
+
+    it("should simulate complete tournament", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      // Round 1: 2 games
+      const pair1 = tournament.getNextPair()!;
+      pair1.player1.score = 5;
+      pair1.player2.score = 2;
+      tournament.storeGameResult(pair1);
+
+      const pair2 = tournament.getNextPair()!;
+      pair2.player1.score = 6;
+      pair2.player2.score = 4;
+      tournament.storeGameResult(pair2);
+
+      expect(tournament.getRound()).toBe(1);
+      expect(tournament.getResults().length).toBe(2);
+
+      // Round 2: finals
+      const final = tournament.getNextPair();
+      expect(final).not.toBeNull();
+      expect(final!.round).toBe(2);
+
+      final!.player1.score = 5;
+      final!.player2.score = 3;
+      tournament.storeGameResult(final!);
+
+      // No more pairs
+      expect(tournament.getNextPair()).toBeNull();
+    });
+  });
+
+  describe("Winner Advancement", () => {
+    it("should advance specified player", () => {
+      const tournament = new Tournament(["A", "B", "C", "D"]);
+
+      const pair = tournament.getNextPair()!;
+      const winner = pair.player1;
+
+      // Manually advance winner
+      tournament.advanceWinner(winner);
+
+      // Get all remaining pairs to check if winner appears
+      const nextPair1 = tournament.getNextPair();
+      const nextPair2 = tournament.getNextPair();
+
+      const hasWinner =
+        (nextPair1 &&
+          (nextPair1.player1.username === winner.username ||
+            nextPair1.player2.username === winner.username)) ||
+        (nextPair2 &&
+          (nextPair2.player1.username === winner.username ||
+            nextPair2.player2.username === winner.username));
+
+      // Winner should appear in the tournament rounds
+      expect(hasWinner || nextPair1 || nextPair2).toBeTruthy();
+    });
+
+    it("should reset advanced player score", () => {
+      const tournament = new Tournament(["A", "B"]);
+
+      const pair = tournament.getNextPair()!;
+      pair.player1.score = 100;
+
+      tournament.advanceWinner(pair.player1);
+
+      expect(pair.player1.score).toBe(0);
+    });
+  });
+
+  describe("Tournament Data Integrity", () => {
+    it("should initialize players with zero scores", () => {
+      const tournament = new Tournament(["A", "B"]);
+
+      const player = tournament.getRandomPlayer();
+
+      expect(player!.score).toBe(0);
+    });
+
+    it("should preserve player usernames through tournament", () => {
+      const names = ["Alice", "Bob", "Charlie"];
+      const tournament = new Tournament(names);
+
+      const results = tournament.getResults();
+      // Results start empty
+      expect(results.length).toBe(0);
+
+      // Get players and verify names
+      const players = [
+        tournament.getRandomPlayer(),
+        tournament.getRandomPlayer(),
+        tournament.getRandomPlayer(),
+      ];
+
+      const playerNames = players.map((p) => p!.username).sort();
+      expect(playerNames).toEqual([...names].sort());
+    });
+  });
+});

--- a/frontend/src/ts/main.ts
+++ b/frontend/src/ts/main.ts
@@ -204,6 +204,11 @@ const initPongPage = async () => {
     router.navigate("/");
   });
 
+  // Listen for Pong to request showing the new game button
+  window.addEventListener("pong:showNewGameButton", () => {
+    showElement(newGameBtn);
+  });
+
   registerHandler(newGameBtn, "click", () => {
     switch (mode) {
       case "ai":
@@ -217,13 +222,16 @@ const initPongPage = async () => {
         break;
       case "tournament":
         currentPong?.startGame(mode);
+        hideElement(newGameBtn);
+        break;
+      case "remote":
+        clearPong();
+        router.navigate("/pong?mode=remote");
         break;
       default:
         clearPong();
-        username = getUsername();
-        userId = getUserId();
         currentPong = new Pong("pong-canvas", `${config.wsUrl}/game`, mode);
-        currentPong.startGame(mode, { userId: parseInt(userId!), username: username! });
+        currentPong.startGame(mode);
         break;
     }
   });
@@ -365,10 +373,19 @@ const initPongPage = async () => {
       showElement(hardBtn);
       break;
     }
+    case "remote": {
+      hideElement(newGameBtn);
+      username = getUsername();
+      userId = getUserId();
+      showElement(canvasContainer);
+      currentPong = new Pong("pong-canvas", `${config.wsUrl}/game`, mode);
+      currentPong.startGame(mode, { userId: parseInt(userId!), username: username! });
+      break;
+    }
     case "friend": {
       if (gameId) {
         showElement(canvasContainer);
-        currentPong = new Pong("pong-canvas", `${config.wsUrl}/game`, mode);
+        currentPong = new Pong("pong-canvas", `${config.wsUrl}/game`, mode, gameId);
         currentPong.startGame(
           mode,
           {

--- a/frontend/src/ts/pong/Pong.ts
+++ b/frontend/src/ts/pong/Pong.ts
@@ -322,7 +322,6 @@ export class Pong {
       if (["remote", "friend"].includes(this.currentGameMode)) {
         const hasUserId = localStorage.getItem("userId") !== null;
         if (!hasUserId) {
-          console.log("🚫 Not reconnecting - user is not authenticated");
           return;
         }
       }

--- a/frontend/src/ts/pong/Pong.ts
+++ b/frontend/src/ts/pong/Pong.ts
@@ -210,7 +210,7 @@ export class Pong {
         // ignore
       }
 
-      // Start periodic auth check for authenticated modes (every 30 seconds)
+      // Start periodic auth check for authenticated modes (every 5 seconds)
       if (["remote", "friend"].includes(this.currentGameMode)) {
         this.startAuthCheck();
       }


### PR DESCRIPTION
- Taking the userId and gameId from the token, not just from the message that is sent (@SilasLovelace I have left 2 TODO comments where I'd like if you'd check out what I'm doing just to make sure, send me change request if its good to remove the comments or if I actually have to change the code)
- Separated logic for message handling based on the mode
- Added a gameManager to store all the game related stuff that is not stored in the database
- users can now reconnect to friend and remote game
- when user logs out in a browser all tabs where authentication needed for the game is redirected to home
- when user switches game to another tab the original also gets redirected to home


I will still add unit tests but you can already test it manually